### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/ export-ignore
+misc/ export-ignore
+benchmark/ export-ignore


### PR DESCRIPTION
The files in tests/ misc/ and benchmark/ are not needed in a production environment.

Adding those directories to the `.gitattributes` file will remove them from the installation when installing the library via `composer install --prefer-dist`

making the installation smaller and faster