### PR TITLE
Allow a configurable ratio for reliability checks in LanguageResult

### DIFF
--- a/src/LanguageResult.php
+++ b/src/LanguageResult.php
@@ -82,7 +82,10 @@ final class LanguageResult
         return $this->prettyScores = $scores;
     }
 
-    public function isReliable(): bool
+    /**
+     * @param float $forAverageScoreRatio Is reliable if score * $forAverageScoreRatio > average score for the language
+     */
+    public function isReliable(float $forAverageScoreRatio = 0.75): bool
     {
         // if undetermined language, or less than 3 ngrams
         if ($this->language === 'und' || count($this->byteNgrams) < 3) {
@@ -92,8 +95,8 @@ final class LanguageResult
         $scores = $this->scores();
         reset($scores); // Make sure the pointer is at the beginning
 
-        // Is reliable if score is >75% of average, and +5% higher than next score. Selected numbers after testing
-        if ($this->avgScore[$this->languageId] * 0.75 > $scores[$this->language]
+        // Is reliable if score is greater than a fraction of the average, and +5% higher than next score. Selected numbers after testing
+        if ($this->avgScore[$this->languageId] * $forAverageScoreRatio > $scores[$this->language]
             || 0.05 > abs($scores[$this->language] - next($scores)) / $scores[$this->language]) {
             return false;
         }


### PR DESCRIPTION
This PR adds functionality to use a configurable ratio for reliability checks. In our domain we struggled with a little too strict reliable check. Our use case is a bit less strict and we experimented with different ratios of the average. We were a bit more content with 0.5 as ratio for our language detection, as we use it for a large collection of short sentences.

Could you have a look and determine if this is something you are willing to merge? Currently we use a workaround with reflection, which is less than optimal.

Functionally is it not a breaking change, as the method can still be used without passing a ratio.